### PR TITLE
docs: typo in README (Memery -> Memory)

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 
 ## Models
 
-|Model        | Resolution|#Views    |GPU Memery<br>(w/ refinement)|#Training Scans|Datasets|
+|Model        | Resolution|#Views    |GPU Memory<br>(w/ refinement)|#Training Scans|Datasets|
 |:-----------:|:---------:|:--------:|:--------:|:--------:|:--------:|
 |unet_uv      |512x512    |-         |-GB    |~2500     |[THuman2.1](https://github.com/ytrock/THuman2.0-Dataset)|
 |unet_color   |1024x1024  |2         |-GB    |~5500     |[THuman2.1](https://github.com/ytrock/THuman2.0-Dataset), [2K2K](https://github.com/SangHunHan92/2K2K)|


### PR DESCRIPTION
- Corrected "GPU Memery" to "GPU Memory" in the models table header.